### PR TITLE
Bump up to 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.6
+- description() is deprecated since 1.42.0, replaced by Display
+
 # 0.1.5
 - fully qualified the Result type within the macro definitions
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,18 @@ tokio-pg-mapper-derive = { version = "0.1.4", optional = true}
 
 [features]
 derive = ["tokio-pg-mapper-derive"]
+
+[workspace]
+members=[
+    ".",
+    "pg_mapper_derive",
+]
+
+[profile.release]
+lto = true
+opt-level = 3
+codegen-units = 1
+
+[patch.crates-io]
+tokio-pg-mapper = { path = "." }
+tokio-pg-mapper-derive = { path = "pg_mapper_derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-pg-mapper"
-version = "0.1.5"
+version = "0.1.6"
 description = "Proc-macro library used to map a tokio-postgres row to a Rust type (struct)"
 authors = ["Darin Gordon <dkcdkg@gmail.com>", "Zeyla Hellyer <zeyla@hellyer.dev>"]
 repository = "https://www.github.com/Dowwie/tokio-postgres-mapper"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,9 +122,8 @@ pub trait FromTokioPostgresRow: Sized {
     ///     }
     /// ```
     fn sql_table() -> String;
-    
-    
-    /// Get a list of the field names, excluding table name prefix. 
+
+    /// Get a list of the field names, excluding table name prefix.
     ///
     /// Example:
     ///
@@ -187,15 +186,18 @@ impl From<Box<dyn StdError + Send + Sync>> for Error {
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        f.write_str(self.description())
+        match self {
+            Error::ColumnNotFound => write!(f, "Column in row not found"),
+            Error::Conversion(inner) => write!(f, "{}", inner),
+        }
     }
 }
 
 impl StdError for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::ColumnNotFound => "Column in row not found",
-            Error::Conversion(ref inner) => inner.description(),
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Error::ColumnNotFound => None,
+            Error::Conversion(inner) => Some(inner.as_ref()),
         }
     }
 }


### PR DESCRIPTION
description() is deprecated since 1.42.0, replaced by Display