### PR TITLE
Displaying Error leads to stackoverflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.8
+- Fixed Display impl for Error causing stackoverflow
+
 # 0.1.7
 - refactored std::Error impl, replacing deprecated 'fn description' with 'fn source'
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-pg-mapper"
-version = "0.1.7"
+version = "0.1.8"
 description = "Proc-macro library used to map a tokio-postgres row to a Rust type (struct)"
 authors = ["Darin Gordon <dkcdkg@gmail.com>", "Zeyla Hellyer <zeyla@hellyer.dev>"]
 repository = "https://www.github.com/Dowwie/tokio-postgres-mapper"
@@ -13,8 +13,8 @@ edition = "2018"
 doctest = false
 
 [dependencies]
-tokio-postgres = "0.5.1"
-tokio-pg-mapper-derive = { version = "0.1.4", optional = true}
+tokio-postgres = "0.5.4"
+tokio-pg-mapper-derive = { version = "0.1.5", path = "./pg_mapper_derive", optional = true }
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 
 [dependencies]
 tokio-postgres = "0.5.4"
-tokio-pg-mapper-derive = { version = "0.1.5", path = "./pg_mapper_derive", optional = true }
+tokio-pg-mapper-derive = { version = "0.1.5", optional = true }
 
 
 [features]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies.tokio-postgres-mapper]
-path="../tokio-postgres-mapper"
+[dependencies.tokio-pg-mapper]
+path=".."
 features=["derive"]
+
+[dependencies]
+tokio-postgres = "0.5.4"

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -2,6 +2,7 @@
 extern crate tokio_pg_mapper_derive;
 
 #[derive(PostgresMapper)]
+#[pg_mapper(table = "user")]
 pub struct User {
     pub id: i64,
     pub name: String,

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate tokio_pg_mapper_derive;
+use tokio_pg_mapper::PostgresMapper;
 
 #[derive(PostgresMapper)]
 #[pg_mapper(table = "user")]


### PR DESCRIPTION
Hi @Dowwie 
impl Display is using self.to_string(), which in turn uses impl Display, which is leading to infinite recursion. This PR is fixing impl Display for Error.

I've also fixed example so that it compiles and amended CHANGELOG.