### PR TITLE
Fix examples feature requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ doctest = false
 tokio-postgres = "0.5.4"
 tokio-pg-mapper-derive = { version = "0.1.5", optional = true }
 
+[[example]]
+name = "src"
+required-features = ["derive"]
 
 [features]
 derive = ["tokio-pg-mapper-derive"]


### PR DESCRIPTION
Provided example require "derive" feature, which is not clear from error message when trying to run example via `cargo run --example`:
```
❯ cargo run --example src
warning: unused manifest key: example.0.features
   Compiling tokio-pg-mapper v0.1.8 (/Users/max/src/rust/actica/tokio-postgres-mapper)
error[E0432]: unresolved import `tokio_pg_mapper::PostgresMapper`
 --> examples/src/main.rs:1:5
  |
1 | use tokio_pg_mapper::PostgresMapper;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `PostgresMapper` in the root
```

After PR:
```
> cargo run --example src
error: target `src` in package `tokio-pg-mapper` requires the features: `derive`
Consider enabling them by passing, e.g., `--features="derive"`

> cargo run --example src --features="derive"
   Compiling tokio-pg-mapper v0.1.8 (/Users/max/src/rust/actica/tokio-postgres-mapper)
    Finished dev [unoptimized + debuginfo] target(s) in 2.74s
     Running `target/debug/examples/src`

```

