### PR TITLE
Allow raw identifiers as column names

### DIFF
--- a/pg_mapper_derive/src/lib.rs
+++ b/pg_mapper_derive/src/lib.rs
@@ -3,6 +3,8 @@ extern crate proc_macro;
 extern crate quote;
 extern crate syn;
 
+use syn::ext::IdentExt;
+
 use proc_macro::TokenStream;
 
 use syn::{
@@ -58,7 +60,7 @@ fn impl_tokio_pg_mapper(
         let ident = field.ident.as_ref().unwrap();
         let ty = &field.ty;
 
-        let row_expr = format!(r##"{}"##, ident);
+        let row_expr = format!(r##"{}"##, ident.unraw());
         quote! {
             #ident:row.try_get::<&str,#ty>(#row_expr)?
         }
@@ -68,7 +70,7 @@ fn impl_tokio_pg_mapper(
         let ident = field.ident.as_ref().unwrap();
         let ty = &field.ty;
 
-        let row_expr = format!(r##"{}"##, ident);
+        let row_expr = format!(r##"{}"##, ident.unraw());
         quote! {
             #ident:row.try_get::<&str,#ty>(&#row_expr)?
         }
@@ -82,7 +84,7 @@ fn impl_tokio_pg_mapper(
                 .ident
                 .as_ref()
                 .expect("Expected structfield identifier");
-            format!(" {0}.{1} ", table_name, ident)
+            format!(" {0}.{1} ", table_name, ident.unraw())
         })
         .collect::<Vec<String>>()
         .join(", ");
@@ -95,7 +97,7 @@ fn impl_tokio_pg_mapper(
                 .ident
                 .as_ref()
                 .expect("Expected structfield identifier");
-            format!(" {} ", ident)
+            format!(" {} ", ident.unraw())
         })
         .collect::<Vec<String>>()
         .join(", ");


### PR DESCRIPTION
In Rust, we can use the `r#` prefix to define fields with names that match built-in keywords like `type`, e.g.:

```rust
pub struct Foo {
  pub r#type: i64
}
```

Currently, when we derive the `FromTokioPostgresRow` trait using `#[derive(PostgresMapper)]` on a struct with fields that have the `r#` prefix, queries against the said fields with an error such as the following:

```
Failed to map database entities: UnknownTokioPG("invalid column `r#type`")
```

This happens because when we build queries, we pass the identifier name as-is, without removing this prefix, and the term `r#type` ends up in the query sent to Postgres. By using the `unraw()` method in the `IdentExt` trait of the `syn` package, however, we can remove the prefix from the identifier and make sure that we don't end up with invalid queries.

Note that it's safe to call `unraw()` regardless of the fact that fields are prefixed or not, because it has no effect regular identifier names.

This PR updates the usages of identifiers by calling `unraw()` to make sure they're not prefixed with `r#`.